### PR TITLE
Bind ‘I’ (uppercase ‘i’) to evil-window-bottom

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,13 @@ operator-pending state (``o``, inherits from motion state):
      - yes
      -
 
+   * - ``I``
+     - ``L``
+     - jump to bottom of window
+     - ``mnvo``
+     - yes
+     -
+
    * - ``l``, ``L``
      - ``u``, ``U``
      - downcase/upcase

--- a/evil-colemak-basics.el
+++ b/evil-colemak-basics.el
@@ -76,9 +76,12 @@ rotated; see evil-colemak-basics-rotate-t-f-j."
       "n" 'evil-next-line
       "gn" 'evil-next-visual-line
       "e" 'evil-previous-line
-      "ge" 'evil-previous-visual-line
       "E" 'evil-lookup
+      "ge" 'evil-previous-visual-line
       "i" 'evil-forward-char
+      "I" 'evil-window-bottom
+      "zi" 'evil-scroll-column-right
+      "zI" 'evil-scroll-right
       "j" 'evil-forward-word-end
       "J" 'evil-forward-WORD-end
       "gj" 'evil-backward-word-end
@@ -86,9 +89,7 @@ rotated; see evil-colemak-basics-rotate-t-f-j."
       "k" 'evil-search-next
       "K" 'evil-search-previous
       "gk" 'evil-next-match
-      "gK" 'evil-previous-match
-      "zi" 'evil-scroll-column-right
-      "zI" 'evil-scroll-right)
+      "gK" 'evil-previous-match)
     (evil-define-key '(normal visual) keymap
       "N" 'evil-join
       "gN" 'evil-join-whitespace)


### PR DESCRIPTION
In Vim, following our design rationale, `L` would be bound to the command "undo all latest changes on the line".  So, should Evil
implement that Vim command, we won't be caught off guard.

Oh, and I've also reordered lines a bit, following some simple logic. Let me know if you had another one in your mind.

If that change is OK, shall I reflect that binding in readme?