### PR TITLE
Bind gu/gU to their respective insert commands

### DIFF
--- a/evil-colemak-basics.el
+++ b/evil-colemak-basics.el
@@ -92,11 +92,15 @@ rotated; see evil-colemak-basics-rotate-t-f-j."
       "gK" 'evil-previous-match)
     (evil-define-key '(normal visual) keymap
       "N" 'evil-join
-      "gN" 'evil-join-whitespace)
+      "gN" 'evil-join-whitespace
+      "gl" 'evil-downcase
+      "gL" 'evil-upcase)
     (evil-define-key 'normal keymap
       "l" 'evil-undo
       "u" 'evil-insert
-      "U" 'evil-insert-line)
+      "U" 'evil-insert-line
+      "gu" 'evil-insert-resume
+      "gU" 'evil-insert-0-line)
     (evil-define-key 'visual keymap
       "l" 'evil-downcase
       "L" 'evil-upcase


### PR DESCRIPTION
Warning! This PR might break [your muscle memory](https://github.com/wbolster/emacs-evil-colemak-basics/pull/11#issuecomment-938523749). :wink: 

In addition to `i` and `I`, Vim and Evil have two more insert commands mapped to `gi` and `gI`. I, for one, didn't know of them until recently, before perusing Vim's help system for its bindings related to our Colemak remapping. As fancy as they might seem, I think we should not disregard them. In particular, our README states that
> …variations like `gn` and `ge` (`gj` and `gk` on Qwerty) to navigate visual lines instead of real lines also behave as expected.

So, some Vim veteran would expect all those four insert command to be on one key.

Then, we have to rebind the downcase/upcase commands (`gu` and `gU`) to `gl` and `gL`, resp. That's a natural choice after 59b0f5b.

What do you think?