### PR TITLE
Fix search pattern sync on k/K

### DIFF
--- a/evil-colemak-basics.el
+++ b/evil-colemak-basics.el
@@ -86,8 +86,8 @@ rotated; see evil-colemak-basics-rotate-t-f-j."
       "J" 'evil-forward-WORD-end
       "gj" 'evil-backward-word-end
       "gJ" 'evil-backward-WORD-end
-      "k" 'evil-search-next
-      "K" 'evil-search-previous
+      "k" (if (eq evil-search-module 'evil-search) 'evil-ex-search-next 'evil-search-next)
+      "K" (if (eq evil-search-module 'evil-search) 'evil-ex-search-previous 'evil-search-previous)
       "gk" 'evil-next-match
       "gK" 'evil-previous-match)
     (evil-define-key '(normal visual) keymap


### PR DESCRIPTION
I noticed that after a `/` or `*` search (or their backwards equivalents), the `k` and `K` bindings weren't synchronised with my most recent search. This change seems to fix it for me.