### PR TITLE
Fix evil-snipe-t and evil-snipe-j

### DIFF
--- a/evil-colemak-basics.el
+++ b/evil-colemak-basics.el
@@ -133,8 +133,8 @@ rotated; see evil-colemak-basics-rotate-t-f-j."
           "J" 'evil-find-char-to-backward))
        ((eq evil-colemak-basics-char-jump-commands 'evil-snipe)
         ;; XXX https://github.com/hlissner/evil-snipe/issues/46
-        (evil-snipe-def 1 inclusive "t" "T")
-        (evil-snipe-def 1 exclusive "j" "J")
+        (evil-snipe-def 1 'inclusive "t" "T")
+        (evil-snipe-def 1 'exclusive "j" "J")
         (evil-define-key '(motion normal visual) keymap
           "t" 'evil-snipe-t
           "T" 'evil-snipe-T


### PR DESCRIPTION
Running `evil-snipe-T` or `evil-snipe-t` using the keys or by manually running the command fails. It spits the following error message: `funcall-interactively: Symbol’s value as variable is void: inclusive.`

The same is true for `evil-snipe-J` and `evil-snipe-j`, however it outputs `funcall-interactively: Symbol’s value as variable is void: exclusive.`

Upon checking the source for both evil-snipe and evil-colemak-basic, https://github.com/hlissner/evil-snipe/commit/c2108d3932fcd2f75ac3e48250d6badd668f5b4f changed how it handled the argument and how `evil-snipe-def` was called.

This commit fixes this by replicating how `evil-snipe-def` was called within evil-snipe.
